### PR TITLE
Add string functions and make minor fixes

### DIFF
--- a/canvas.js
+++ b/canvas.js
@@ -1,4 +1,4 @@
-import * as common from "./common.js";
+import * as core from "./core.js";
 import * as theme from "./theme.js";
 
 export const DISP_WIDTH = 640;
@@ -93,6 +93,10 @@ function twoPointsToPointSize(x1, y1, x2, y2) {
 }
 
 export function onReady(callback) {
+    if (window.inDocsPopout) {
+        return;
+    }
+
     readyListeners.push(callback);
 }
 
@@ -282,7 +286,7 @@ export function init() {
 };
 
 export function toggleDocs() {
-    if (!!common.getParameter("embed")) {
+    if (!!core.getParameter("embed")) {
         window.open("/docspopout.html");
 
         return;

--- a/common.js
+++ b/common.js
@@ -1,6 +1,8 @@
 import * as canvas from "./canvas.js";
 import * as basic from "./basic.js";
 
+export * from "./core.js";
+
 function hueToRgb(p, q, t) {
     if (t < 0) {
         t += 1;
@@ -23,10 +25,6 @@ function hueToRgb(p, q, t) {
     }
 
     return p;
-}
-
-export function getParameter(name) {
-    return decodeURIComponent((new RegExp("[?|&]" + name + "=" + "([^&;]+?)(&|#|;|$)").exec(location.search) || [null, ""])[1].replace(/\+/g, "%20")) || null;
 }
 
 export function colourFromHsl(hue, saturation, luminance, alpha = 1, trigMode = basic.trigMode) {

--- a/core.js
+++ b/core.js
@@ -1,0 +1,3 @@
+export function getParameter(name) {
+    return decodeURIComponent((new RegExp("[?|&]" + name + "=" + "([^&;]+?)(&|#|;|$)").exec(location.search) || [null, ""])[1].replace(/\+/g, "%20")) || null;
+}

--- a/docs/reference/functions.md
+++ b/docs/reference/functions.md
@@ -412,12 +412,50 @@ Finds the last item in the list given as argument `x`. If `x` is empty, then an 
 </pre>
 </details>
 
-## `lower$`
+## `split`
 ```
-lower$(x)
+split(str$, delim$)
+split(str$)
 ```
 
-Converts the string expression given as argument `x` to a lower case string.
+Converts the string expression given as argument `str$` into a list, with the string split by the delimeter given as argument `delim$`. If `delim$` is not present or is set to `""`, then `str$` will be split into its constituent characters.
+
+<details>
+<summary>Example</summary>
+<pre>
+<code>10 print "My shopping list:"</code>
+<code>20 shopping=split("apple,orange,banana", ",")</code>
+<code>30 for i=0 to len(shopping)-1</code>
+<code>40 print shopping[i]</code>
+<code>50 next</code>
+</pre>
+</details>
+
+## `join$`
+```
+join$(items, delim$)
+join$(items)
+```
+
+Convers the list given as argument `items` into a string, with the list joined by the delimeter given as argument `delim$`. If `delim$` is not present, then the list will be joined by no delimeter.
+
+<details>
+<summary>Example</summary>
+<pre>
+<code>10 dim shopping</code>
+<code>20 push "apple", shopping</code>
+<code>30 push "orange", shopping</code>
+<code>40 push "banana", shopping</code>
+<code>50 print join$(shopping, "; ")</code>
+</pre>
+</details>
+
+## `lower$`
+```
+lower$(str$)
+```
+
+Converts the string expression given as argument `str$` to a lower case string.
 
 <details>
 <summary>Example</summary>
@@ -428,10 +466,10 @@ Converts the string expression given as argument `x` to a lower case string.
 
 ## `upper$`
 ```
-upper$(x)
+upper$(str$)
 ```
 
-Converts the string expression given as argument `x` to an upper case string.
+Converts the string expression given as argument `str$` to an upper case string.
 
 <details>
 <summary>Example</summary>
@@ -440,12 +478,54 @@ Converts the string expression given as argument `x` to an upper case string.
 </pre>
 </details>
 
-## `trim$`
+## `left$`
 ```
-trim$(x)
+left$(str$, a)
 ```
 
-Removes leading and trailing whitespace characters on the string expression given as argument `x`.
+Returns the first `a` characters of the string expression given as argument `str$`.
+
+<details>
+<summary>Example</summary>
+<pre>
+<code>10 print left$("Hello, world!", 5)</code>
+</pre>
+</details>
+
+## `right$`
+```
+right$(str$, a)
+```
+
+Returns the last `a` characters of the string expression given as argument `str$`.
+
+<details>
+<summary>Example</summary>
+<pre>
+<code>10 print right$("Hello, world!", 6)</code>
+</pre>
+</details>
+
+## `mid$`
+```
+right$(str$, a, b)
+```
+
+Returns a portion of the string expression given as argument `str$`, where the start is given as argument `a`, and the length is given as argument `b`.
+
+<details>
+<summary>Example</summary>
+<pre>
+<code>10 print mid$("Hello, world!", 1, 4)</code>
+</pre>
+</details>
+
+## `trim$`
+```
+trim$(str$)
+```
+
+Removes leading and trailing whitespace characters on the string expression given as argument `str$`.
 
 <details>
 <summary>Example</summary>
@@ -456,10 +536,10 @@ Removes leading and trailing whitespace characters on the string expression give
 
 ## `ltrim$`
 ```
-ltrim$(x)
+ltrim$(str$)
 ```
 
-Removes leading whitespace characters on the string expression given as argument `x`.
+Removes leading whitespace characters on the string expression given as argument `str$`.
 
 <details>
 <summary>Example</summary>
@@ -470,10 +550,10 @@ Removes leading whitespace characters on the string expression given as argument
 
 ## `rtrim$`
 ```
-rtrim$(x)
+rtrim$(str$)
 ```
 
-Removes trailing whitespace characters on the string expression given as argument `x`.
+Removes trailing whitespace characters on the string expression given as argument `str$`.
 
 <details>
 <summary>Example</summary>

--- a/docspopout.html
+++ b/docspopout.html
@@ -8,7 +8,7 @@
         <meta name="application-name" content="atto guide">
         <meta name="theme-color" content="#ffffff">
         <meta property="og:title" content="atto guide">
-        <meta property="og:image" content="https://jamesl.me/atto/media/cover.png">
+        <meta property="og:image" content="https://atto.devicefuture.org/media/cover.png">
         <meta property="og:image:type" content="image/png">
         <link rel="icon" href="media/logo.png">
         <link rel="manifest" href="manifest.webmanifest">

--- a/docspopout.js
+++ b/docspopout.js
@@ -1,14 +1,13 @@
-import * as syntax from "./syntax.js";
-window.syntax = syntax;
-
-import * as common from "./common.js";
-
 window.inDocsPopout = true;
 
 window.addEventListener("load", function() {
-    if (common.getParameter("page") != null) {
-        visitDocumentation(common.getParameter("page"));
-    } else {
-        visitDocumentation("docs/index.md");
-    }
+    Promise.all([import("./common.js"), import("./syntax.js")]).then(function([common, syntax]) {
+        window.syntax = syntax;
+    
+        if (common.getParameter("page") != null) {
+            visitDocumentation(common.getParameter("page"));
+        } else {
+            visitDocumentation("docs/index.md");
+        }
+    });
 });

--- a/hid.js
+++ b/hid.js
@@ -369,6 +369,10 @@ function renderLoop() {
 }
 
 window.addEventListener("load", function() {
+    if (window.inDocsPopout) {
+        return;
+    }
+
     hidLog = document.querySelector("#hidLog");
     hidLive = document.querySelector("#hidLive");
     hidInput = document.querySelector("#hidInput");

--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
         <meta name="application-name" content="atto - code ur dreams">
         <meta name="theme-color" content="#ffffff">
         <meta property="og:title" content="atto - code ur dreams">
-        <meta property="og:image" content="https://jamesl.me/atto/media/cover.png">
+        <meta property="og:image" content="https://atto.devicefuture.org/media/cover.png">
         <meta property="og:image:type" content="image/png">
         <link rel="icon" href="media/logo.png">
         <link rel="manifest" href="manifest.webmanifest">

--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,4 @@
-const cacheName = "atto-cv8"; // Increment for every major change
+const cacheName = "atto-cv9"; // Increment for every major change
 
 self.addEventListener("install", function(event) {
     event.waitUntil(caches.open(cacheName).then(function(cache) {
@@ -13,6 +13,7 @@ self.addEventListener("install", function(event) {
             "/bot.js",
             "/canvas.js",
             "/commands.js",
+            "/core.js",
             "/common.js",
             "/hid.js",
             "/syntax.js",


### PR DESCRIPTION
This PR adds some useful string manipulation functions, such as `left$`, `right$`, `mid$`, `split` and `join$`. It also fixes the pop-out documentation syntax highlighting, which was previously broken.