### PR TITLE
Docs UX improvements

### DIFF
--- a/docs.js
+++ b/docs.js
@@ -4,12 +4,12 @@ const TWITTER_HANDLE = "@codeurdreams";
 var currentPage = null;
 var oldTweet = null;
 
-function visitDocumentation(path) {
+function visitDocumentation(path, updateUrl = true) {
     path = path.replace(/^docs\/\//g, "docs/");
 
     currentPage = path;
     
-    if (window.inDocsPopout) {
+    if (window.inDocsPopout && updateUrl) {
         window.history.pushState("", "", `${window.location.href.split("?")[0]}?page=${path}`);
     }
 

--- a/docs.js
+++ b/docs.js
@@ -20,6 +20,8 @@ function visitDocumentation(path) {
 
         document.querySelector("#docsContent").innerHTML = converter.makeHtml(data);
 
+        document.querySelector("#docsContent").scrollTo(0, 0);
+
         document.querySelectorAll("a").forEach(function(element) {
             var destination = element.getAttribute("href") || "";
 
@@ -44,6 +46,10 @@ function visitDocumentation(path) {
             document.querySelectorAll("details").forEach(function(element) {
                 element.open = true;
             });
+
+            if (window.location.hash == "") {
+                window.scrollTo(0, 0);
+            }
         }
 
         oldTweet = null;

--- a/docspopout.js
+++ b/docspopout.js
@@ -4,10 +4,18 @@ window.addEventListener("load", function() {
     Promise.all([import("./common.js"), import("./syntax.js")]).then(function([common, syntax]) {
         window.syntax = syntax;
     
-        if (common.getParameter("page") != null) {
-            visitDocumentation(common.getParameter("page"));
-        } else {
-            visitDocumentation("docs/index.md");
+        function loadDocumentation(updateUrl = true) {
+            if (common.getParameter("page") != null) {
+                visitDocumentation(common.getParameter("page"), updateUrl);
+            } else {
+                visitDocumentation("docs/index.md", updateUrl);
+            }
         }
+
+        window.addEventListener("popstate", function() {
+            loadDocumentation(false);
+        });
+
+        loadDocumentation();
     });
 });

--- a/style.css
+++ b/style.css
@@ -504,6 +504,10 @@ h1.reference a.comparators {
         break-inside: avoid;
     }
 
+    pre {
+        white-space: pre-wrap;
+    }
+
     details:not([open]) {
         display: none;
     }


### PR DESCRIPTION
This PR improves upon the UX of the documentation viewer with these fixes:
* Whenever a link is followed in a guide, the subsequent page is always scrolled to the top
* When there are lines that are too long to fit horizontally on a page in code blocks, the printed version of the page wraps those lines
* Using the back/forward browser buttons in the docs popout now navigates through the guides as expected

This PR fixes issue #37.